### PR TITLE
Allow usage of an external qualifier for peripherals

### DIFF
--- a/blessed/src/main/java/com/welie/blessed/BluetoothCentralManager.kt
+++ b/blessed/src/main/java/com/welie/blessed/BluetoothCentralManager.kt
@@ -47,7 +47,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 @SuppressLint("MissingPermission")
 @Suppress("unused")
-class BluetoothCentralManager(private val context: Context, private val bluetoothCentralManagerCallback: BluetoothCentralManagerCallback, private val callBackHandler: Handler) {
+class BluetoothCentralManager(private val context: Context, private val bluetoothCentralManagerCallback: BluetoothCentralManagerCallback, private val callBackHandler: Handler): PeripheralQualifier {
     private val bluetoothAdapter: BluetoothAdapter
 
     @Volatile
@@ -976,6 +976,10 @@ class BluetoothCentralManager(private val context: Context, private val bluetoot
             }
             BluetoothAdapter.STATE_TURNING_ON -> Logger.d(TAG, "bluetooth turning on")
         }
+    }
+
+    override fun isDeviceAPeripheral(device: BluetoothDevice): Boolean {
+        return unconnectedPeripherals.containsKey(device.address)
     }
 
     init {

--- a/blessed/src/main/java/com/welie/blessed/PeripheralQualifier.kt
+++ b/blessed/src/main/java/com/welie/blessed/PeripheralQualifier.kt
@@ -1,0 +1,23 @@
+package com.welie.blessed
+
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGattServerCallback
+
+/**
+ * A PeripheralQualifier instance is used by the [BluetoothPeripheralManager] to discriminate peripheral devices from
+ * central devices.
+ *
+ * The [peripheral manager][BluetoothPeripheralManager] needs to connect to every central that connects to the server,
+ * in order to prevent connectivity issues. See https://issuetracker.google.com/issues/37127644
+ * However, this can cause some issues if the application is used as a BLE server, and a BLE client. Android sends
+ * notifications to the [BluetoothGattServerCallback] for every device connected to the system, peripherals and centrals.
+ * See https://github.com/weliem/blessed-android/issues/156
+ */
+fun interface PeripheralQualifier {
+    /**
+     * Determines whether the given [device] is a peripheral device or a central one.
+     * If the device is a peripheral, the [peripheral manager][BluetoothPeripheralManager] will not initiate a
+     * connection to it.
+     */
+    fun isDeviceAPeripheral(device: BluetoothDevice): Boolean
+}


### PR DESCRIPTION
While using this library to run a BLE server in an application that is also using BLE devices, we encountered the same kind of problems than the ones mentioned here https://github.com/weliem/blessed-android/issues/156.
I noticed that a fix has be proposed for this issue, but it cannot apply in our case. We are not using this library to connect to BLE devices, and this is not something that will be done in a near future.

Instead of using the `BluetoothCentralManager` as unique object used to qualify devices as peripheral or central devices, this PR proposes a way to register external peripheral qualifiers, through a new `PeripheralQualifier` interface.
 `BluetoothPeripheralManager` has been updated to use a `PeripheralQualifier` instead of the `BluetoothCentralManager`.
`BluetoothCentralManager` now also implements `PeripheralQualifier` and can be passed to the `BluetoothPeripheralManager`.