### PR TITLE
Make HeartRateService more reliable

### DIFF
--- a/peripheral/src/main/java/com/welie/btserver/HeartRateService.kt
+++ b/peripheral/src/main/java/com/welie/btserver/HeartRateService.kt
@@ -21,7 +21,7 @@ internal class HeartRateService(peripheralManager: BluetoothPeripheralManager) :
 
     private val measurement = BluetoothGattCharacteristic(
         HEARTRATE_MEASUREMENT_CHARACTERISTIC_UUID,
-        BluetoothGattCharacteristic.PROPERTY_READ or BluetoothGattCharacteristic.PROPERTY_INDICATE,
+        BluetoothGattCharacteristic.PROPERTY_NOTIFY,
         BluetoothGattCharacteristic.PERMISSION_READ
     )
     private val handler = Handler(Looper.getMainLooper())


### PR DESCRIPTION
Various fitness apps (Strava and Wahoo) will only stay connected with PROPERTY_NOTIFY.

I should mention that I don't really know the ins and outs of bluetooth.  I simply compared this example app to one I knew was working.