### PR TITLE
Stop BluetoothLeAdvertiser when Bluetooth is turned off

### DIFF
--- a/blessed/src/main/java/com/welie/blessed/BluetoothPeripheralManager.kt
+++ b/blessed/src/main/java/com/welie/blessed/BluetoothPeripheralManager.kt
@@ -673,7 +673,10 @@ class BluetoothPeripheralManager(private val context: Context, private val bluet
                 Logger.d(TAG, "bluetooth turned off")
                 cancelAllConnectionsWhenBluetoothOff()
             }
-            BluetoothAdapter.STATE_TURNING_OFF -> Logger.d(TAG, "bluetooth turning off")
+            BluetoothAdapter.STATE_TURNING_OFF -> {
+                Logger.d(TAG, "bluetooth turning off")
+                bluetoothLeAdvertiser.stopAdvertising(advertiseCallback)
+            }
             BluetoothAdapter.STATE_ON -> Logger.d(TAG, "bluetooth turned on")
             BluetoothAdapter.STATE_TURNING_ON -> Logger.d(TAG, "bluetooth turning on")
         }


### PR DESCRIPTION
Try to fix https://github.com/weliem/blessed-kotlin/issues/14 that occurs when trying to restart advertising after toggling Bluetooth:

BluetoothP...ralManager com.welie.btserver E advertising failed with error 'ALREADY_STARTED'